### PR TITLE
WIP*2: Only require `libgfortran` at run-time

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# We only want to use `gfortran` from `gcc`.
+# Using all of these has caused some problems.
+# See this issue.
+# ( https://github.com/conda-forge/numpy-feedstock/issues/15 )
+rm "${PREFIX}/bin/gcc"
+rm "${PREFIX}/bin/g++"
+
 # See this workaround
 # ( https://github.com/xianyi/OpenBLAS/issues/818#issuecomment-207365134 ).
 CF="${CFLAGS}"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ build:
 requirements:
   build:
     - python    # [win]
-    - perl      # [win]
+    - perl
     - gcc       # [unix]
 
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   md5: 805e7f660877d588ea7e3792cda2ee65
 
 build:
-  number: 1
+  number: 2
   skip: true  # [win]
   track_features:
     - vc9     # [win and py27]
@@ -19,12 +19,12 @@ build:
 
 requirements:
   build:
-    - python    # [win]
+    - python       # [win]
     - perl
-    - gcc       # [unix]
+    - gcc          # [unix]
 
   run:
-    - libgcc    # [unix]
+    - libgfortran  # [unix]
 
 test:
   commands:


### PR DESCRIPTION
This attempts to use only `libgfortran` as a dependency at run-time dependency. FWICT on Mac only links against `libgfortran`. However, Linux appears to be a mess and links to both `libgcc_s` and `libgfortran`. We try an **extremely** experimental solution to fix this in this PR.