### PR TITLE
Only require `libgfortran` at run-time on Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@
 language: objective-c
 
 env:
+  matrix:
+    
+    - CONDA_PERL=5.20.3.1
   global:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     - secure: "TKJ4kVP75CVTUbLNxJ7nN9S0yQ+UfCohFE36uGYquZzhggbs4xDK61522Wrn+eHu6Xl8VlaGkeQX0WbfLfPTJpQNzzd3K4eUVQnRfrhvwkkP8Zpgq0AArL55oq4VBxJ5i1VbHQrYRVuw9AJ0vSc3iKrGuCyvEUW8ELgdgfsSZmjkJnBZVLWH7URKrT6/THtoEZEw13KWsPl+fr57EI7GPAFEArsuU3+T2m842PLS1FMM5jWoMDTKZWmk6e2bsQlO0ITOIUqE9+WoZlHJM7uZL9XCLygymIhJ8ekMs+zZepLIKWfPKW6Q8InuCqYyL5NrPexPk2goJukvlojq5kpZ7ohPZ1YyzpO3R+5K7VXzy5VMO2i4Zqs+B8/yK4nH3emRZcCUQefQnk03wWgwts3ONM1CyKiqs+H8iz1AVTKfgHNt4RvspylN3TsmsI8RBzDkWpfPXqyUTmavf4GJ4R8e5iLf1Giru5mSbC3HIEFQlA339FtUbWyLwLz8aWfSns5JVJFbU657uTjwTZHoHnJjz8VdJhwRlrqyUCASPGG4PRVCXlRx2FZqnbOkGecqysHnMNwUhid3xE49rVMQZp61k9hk4Tg9Ww0Q1w1eqD8+vv6gHT2bMfuebigooZBnD/ahNY0NesZrhwBOvoXdt0PjP7pJCtHyy/uJZQZ/xeuGhdg="

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -44,6 +44,9 @@ conda install --yes conda-build
 conda info
 
 # Embarking on 1 case(s).
+    set -x
+    export CONDA_PERL=5.20.3.1
+    set +x
     conda build /recipe_root --quiet || exit 1
     /feedstock_root/ci_support/upload_or_check_non_existence.py /recipe_root conda-forge --channel=main || exit 1
 EOF

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,8 @@ requirements:
     - gcc          # [unix]
 
   run:
-    - libgfortran  # [unix]
+    - libgfortran  # [linux]
+    - libgcc       # [osx]
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ build:
 requirements:
   build:
     - python    # [win]
-    - perl      # [win]
+    - perl
     - gcc       # [unix]
 
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,13 +19,14 @@ build:
 
 requirements:
   build:
-    - python       # [win]
+    - python           # [win]
     - perl
-    - gcc          # [unix]
+    - gcc              # [unix]
+    - cloog 0.18.0 10  # [unix]
 
   run:
-    - libgfortran  # [linux]
-    - libgcc       # [osx]
+    - libgfortran      # [linux]
+    - libgcc           # [osx]
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,12 +19,12 @@ build:
 
 requirements:
   build:
-    - python    # [win]
+    - python       # [win]
     - perl
-    - gcc       # [unix]
+    - gcc          # [unix]
 
   run:
-    - libgcc    # [unix]
+    - libgfortran  # [unix]
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   md5: 805e7f660877d588ea7e3792cda2ee65
 
 build:
-  number: 1
+  number: 2
   skip: true  # [win]
   track_features:
     - vc9     # [win and py27]


### PR DESCRIPTION
This attempts to use only `libgfortran` as a dependency at run-time dependency. FWICT on Mac only links against `libgfortran`. However, Linux appears to be a mess and links to both `libgcc_s` and `libgfortran`. We try an **extremely** experimental solution to fix this in this PR.