### PR TITLE
Use libgfortran on OS X

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,6 @@ requirements:
     - python           # [win]
     - perl
     - gcc              # [unix]
-    - cloog 0.18.0 10  # [unix]
 
   run:
     - libgfortran      # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   md5: 805e7f660877d588ea7e3792cda2ee65
 
 build:
-  number: 2
+  number: 3
   skip: true  # [win]
   track_features:
     - vc9     # [win and py27]
@@ -24,8 +24,7 @@ requirements:
     - gcc              # [unix]
 
   run:
-    - libgfortran      # [linux]
-    - libgcc           # [osx]
+    - libgfortran
 
 test:
   commands:


### PR DESCRIPTION
Follow-up on PR ( https://github.com/conda-forge/openblas-feedstock/pull/6 ). Uses `libgfortran` as a run-time dependency on OS X in addition to Linux. This seems to work from local testing, but will require the `libgfortran` package to exist on `conda-forge` before we can proceed. At this point it is merely a matter of waiting for the first Travis CI [build]( https://travis-ci.org/conda-forge/libgfortran-feedstock/builds/144633685 ) to complete and upload a package. If this is failing on Travis CI at that time, please restart to get it to build.

cc @pelson @ocefpaf @msarahan