### PR TITLE
Build LAPACK with `-frecursive`

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -19,7 +19,7 @@ eval export ${LIBRARY_SEARCH_VAR}="${PREFIX}/lib"
 # Build LAPACK.
 # Enable threading. This can be controlled to a certain number by
 # setting OPENBLAS_NUM_THREADS before loading the library.
-make QUIET_MAKE=1 DYNAMIC_ARCH=1 BINARY=${ARCH} NO_LAPACK=0 NO_AFFINITY=1 USE_THREAD=1 CFLAGS="${CF}"
+make QUIET_MAKE=1 DYNAMIC_ARCH=1 BINARY=${ARCH} NO_LAPACK=0 NO_AFFINITY=1 USE_THREAD=1 CFLAGS="${CF}" FFLAGS="-frecursive"
 # Fix paths to ensure they have the $PREFIX in them.
 if [[ `uname` == 'Darwin' ]]; then
     for OPENBLAS_LIB in $( find "${PREFIX}/lib" -name "libopenblas*.dylib" ); do
@@ -37,7 +37,7 @@ if [[ `uname` == 'Darwin' ]]; then
                 "${OPENBLAS_LIB}"
     done
 fi
-make test
+OPENBLAS_NUM_THREADS=$CPU_COUNT make test
 make install PREFIX="${PREFIX}"
 
 # As OpenBLAS, now will have all symbols that BLAS or LAPACK have,

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   md5: 805e7f660877d588ea7e3792cda2ee65
 
 build:
-  number: 4
+  number: 5
   skip: true  # [win]
   track_features:
     - vc9     # [win and py27]


### PR DESCRIPTION
Was seeing this error from OpenBLAS in some BLAS intensive programs. This was often followed by a segfault.

> BLAS : Program is Terminated. Because you tried to allocate too many memory regions.

After a little digging, I found this [suggestion]( https://github.com/xianyi/OpenBLAS/issues/539#issuecomment-92135151 ). As we are using pthreads, this is the right way to go. Rebuilt using this locally and the warning and segfaults went away.