### PR TITLE
Use the `toolchain`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   md5: 805e7f660877d588ea7e3792cda2ee65
 
 build:
-  number: 5
+  number: 6
   skip: true  # [win]
   track_features:
     - vc9     # [win and py27]
@@ -19,6 +19,7 @@ build:
 
 requirements:
   build:
+    - toolchain
     - python           # [win]
     - perl
     - gcc              # [unix]


### PR DESCRIPTION
Starts using the `toolchain` to build this feedstock. Bumps the build number.