### PR TITLE
Fix install name in OSX

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -48,12 +48,8 @@ done
 
 if [[ `uname` == 'Darwin' ]]; then
     # Needs to fix the install name of the dylib so that the downstream projects will link
-    # to libopenblas.0.dylib instead of libopenblasp-r0.2.20.dylib
+    # to libopenblas.dylib instead of libopenblasp-r0.2.20.dylib
     # In linux, SONAME is libopenblas.so.0 instead of libopenblasp-r0.2.20.so, so no change needed
-    if [[ -f ${PREFIX}/lib/libopenblas.0.dylib ]]; then
-        install_name_tool -id ${PREFIX}/lib/libopenblas.0.dylib ${PREFIX}/lib/libopenblas.0.dylib;
-    else
-        exit 1;
-    fi
+    install_name_tool -id ${PREFIX}/lib/libopenblas.dylib ${PREFIX}/lib/libopenblas.dylib;
 fi
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -45,3 +45,15 @@ for arg in blas cblas lapack; do
     ln -fs $PREFIX/lib/libopenblas.a $PREFIX/lib/lib$arg.a
     ln -fs $PREFIX/lib/libopenblas$SHLIB_EXT $PREFIX/lib/lib$arg$SHLIB_EXT
 done
+
+if [[ `uname` == 'Darwin' ]]; then
+    # Needs to fix the install name of the dylib so that the downstream projects will link
+    # to libopenblas.0.dylib instead of libopenblasp-r0.2.20.dylib
+    # In linux, SONAME is libopenblas.so.0 instead of libopenblasp-r0.2.20.so, so no change needed
+    if [[ -f ${PREFIX}/lib/libopenblas.0.dylib ]]; then
+        install_name_tool -id ${PREFIX}/lib/libopenblas.0.dylib ${PREFIX}/lib/libopenblas.0.dylib;
+    else
+        exit 1;
+    fi
+fi
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 5ef38b15d9c652985774869efd548b8e3e972e1e99475c673b25537ed7bcf394
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
   track_features:
     - vc9     # [win and py27]


### PR DESCRIPTION
Fixes the install name of the dylib so that the downstream projects will link to libopenblas.dylib instead of libopenblasp-r0.2.20.dylib
In Linux, SONAME is libopenblas.so.0 instead of libopenblasp-r0.2.20.so, so no change needed.

This change means the pinning doesn't have to be restrictive as before (https://github.com/conda-forge/conda-forge.github.io/pull/418) and can be as below
```yaml
requirements:
   build:
     - openblas 0.2.20
   run:
     - openblas >=0.2.15
```

One other advantage is that this achieves compatibility with the defaults openblas and therefore a package compiled with conda-forge openblas can use the defaults' openblas at runtime.

cc @ocefpaf