### PR TITLE
Remove unnecessary patching of libraries

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -17,23 +17,6 @@ eval export ${LIBRARY_SEARCH_VAR}="${PREFIX}/lib"
 # Enable threading. This can be controlled to a certain number by
 # setting OPENBLAS_NUM_THREADS before loading the library.
 make QUIET_MAKE=1 DYNAMIC_ARCH=1 BINARY=${ARCH} NO_LAPACK=0 NO_AFFINITY=1 USE_THREAD=1 CFLAGS="${CF}" FFLAGS="-frecursive"
-# Fix paths to ensure they have the $PREFIX in them.
-if [[ `uname` == 'Darwin' ]]; then
-    for OPENBLAS_LIB in $( find "${PREFIX}/lib" -name "libopenblas*.dylib" ); do
-        install_name_tool -change \
-                @rpath/./libgfortran.3.dylib \
-                "${PREFIX}/lib/libgfortran.3.dylib" \
-                "${OPENBLAS_LIB}"
-        install_name_tool -change \
-                @rpath/./libquadmath.0.dylib \
-                "${PREFIX}/lib/libquadmath.0.dylib" \
-                "${OPENBLAS_LIB}"
-        install_name_tool -change \
-                @rpath/./libgcc_s.1.dylib \
-                "${PREFIX}/lib/libgcc_s.1.dylib" \
-                "${OPENBLAS_LIB}"
-    done
-fi
 OPENBLAS_NUM_THREADS=$CPU_COUNT make test
 make install PREFIX="${PREFIX}"
 


### PR DESCRIPTION
This is not used at all, because the patching was done before `make install` making it a no op.