### PR TITLE
Include unversioned libopenblas64_.so for Julia

### DIFF
--- a/.ci_support/osx_64_SYMBOLSUFFIX64_name_suffix-ilp64.yaml
+++ b/.ci_support/osx_64_SYMBOLSUFFIX64_name_suffix-ilp64.yaml
@@ -18,6 +18,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '9'
+llvm_openmp:
+- '11'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 name_suffix:

--- a/.ci_support/osx_64_SYMBOLSUFFIXname_suffix.yaml
+++ b/.ci_support/osx_64_SYMBOLSUFFIXname_suffix.yaml
@@ -18,6 +18,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '9'
+llvm_openmp:
+- '11'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 name_suffix:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -18,6 +18,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '11'
+llvm_openmp:
+- '11'
 macos_machine:
 - arm64-apple-darwin20.0.0
 name_suffix:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Package license: BSD-3-Clause
 
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/openblas-feedstock/blob/master/LICENSE.txt)
 
-Summary: An optimized BLAS library based on GotoBLAS2 1.13 BSD version
+Summary: An optimized BLAS library (ILP64 interface) based on GotoBLAS2 1.13 BSD version
 
 Current build status
 ====================
@@ -152,7 +152,9 @@ Current release info
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-libopenblas-green.svg)](https://anaconda.org/conda-forge/libopenblas) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/libopenblas.svg)](https://anaconda.org/conda-forge/libopenblas) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/libopenblas.svg)](https://anaconda.org/conda-forge/libopenblas) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/libopenblas.svg)](https://anaconda.org/conda-forge/libopenblas) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-libopenblas--ilp64-green.svg)](https://anaconda.org/conda-forge/libopenblas-ilp64) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/libopenblas-ilp64.svg)](https://anaconda.org/conda-forge/libopenblas-ilp64) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/libopenblas-ilp64.svg)](https://anaconda.org/conda-forge/libopenblas-ilp64) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/libopenblas-ilp64.svg)](https://anaconda.org/conda-forge/libopenblas-ilp64) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-openblas-green.svg)](https://anaconda.org/conda-forge/openblas) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/openblas.svg)](https://anaconda.org/conda-forge/openblas) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/openblas.svg)](https://anaconda.org/conda-forge/openblas) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/openblas.svg)](https://anaconda.org/conda-forge/openblas) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-openblas--ilp64-green.svg)](https://anaconda.org/conda-forge/openblas-ilp64) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/openblas-ilp64.svg)](https://anaconda.org/conda-forge/openblas-ilp64) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/openblas-ilp64.svg)](https://anaconda.org/conda-forge/openblas-ilp64) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/openblas-ilp64.svg)](https://anaconda.org/conda-forge/openblas-ilp64) |
 
 Installing openblas
 ===================
@@ -164,10 +166,10 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `libopenblas, openblas` can be installed with:
+Once the `conda-forge` channel has been enabled, `libopenblas, libopenblas-ilp64, openblas, openblas-ilp64` can be installed with:
 
 ```
-conda install libopenblas openblas
+conda install libopenblas libopenblas-ilp64 openblas openblas-ilp64
 ```
 
 It is possible to list all of the versions of `libopenblas` available on your platform with:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "0.3.17" %}
-{% set build_number = 0 %}
+{% set build_number = 1 %}
 
 package:
   name: openblas
@@ -53,7 +53,7 @@ outputs:
       #   - libopenblasp-r0.3.5.so
       #   - libopenblas_vortexp-r0.3.5.so
       #   - libopenblas.so.0
-      #   - libopenblasw64_.so
+      #   - libopenblas64_.so
       - lib/libopenblas{{ SYMBOLSUFFIX }}*p*{{ SHLIB_EXT }}   # [not win]
       - lib/libopenblas{{ SYMBOLSUFFIX }}.so                 # [linux]
       - lib/libopenblas{{ SYMBOLSUFFIX }}.so.*               # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -53,9 +53,9 @@ outputs:
       #   - libopenblasp-r0.3.5.so
       #   - libopenblas_vortexp-r0.3.5.so
       #   - libopenblas.so.0
-      # Avoid files
-      #   - libopenblas.so
+      #   - libopenblasw64_.so
       - lib/libopenblas{{ SYMBOLSUFFIX }}*p*{{ SHLIB_EXT }}   # [not win]
+      - lib/libopenblas{{ SYMBOLSUFFIX }}.so                 # [linux]
       - lib/libopenblas{{ SYMBOLSUFFIX }}.so.*               # [linux]
       - lib/libopenblas{{ SYMBOLSUFFIX }}.*.dylib            # [osx]
       - Library/bin/openblas{{ SYMBOLSUFFIX }}.dll           # [win]


### PR DESCRIPTION
This change will include libopenblas.so and libopenblasw64_.so in the tarball.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [-] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

This change is meant to assist in updating the Julia feedstock recipe to a recent version of Julia and to also enable compatibility with Julia's binarybuilder.org packages.
 
Julia's build process as well additional binary packages from Julia reference an unversioned libopenblas64_.so on 64-bit platforms:

https://github.com/JuliaLang/julia/blob/e6e79f7ab4549ab4d6ffbad22038ebfce1368f93/stdlib/OpenBLAS_jll/src/OpenBLAS_jll.jl#L26-L32

Including a symlink that does not have the version suffix `.0` would greatly aid in bringing recent versions of Julia to conda-forge.