### PR TITLE
Pin the matching openmp variant in run_exports

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "0.3.20" %}
-{% set build_number = 0 %}
+{% set build_number = 1 %}
 
 package:
   name: openblas

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,7 +40,8 @@ outputs:
       track_features:
         - openblas_threading_openmp  # [linux and USE_OPENMP == 1]
       run_exports:
-        - {{ pin_subpackage("libopenblas" ~ name_suffix) }}
+        - {{ pin_subpackage("libopenblas" ~ name_suffix) }} =*openmp* # [USE_OPENMP == 1]
+        - {{ pin_subpackage("libopenblas" ~ name_suffix) }} =*pthreads* # [USE_OPENMP == 0]
     requirements:
       build:
         - {{ compiler("c") }}


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

The run_exports currently doesn't specify which openmp variant to pin, this results in the situation where a user may compile using the openmp variant, but then end up runing using the pthreads variant.

<!--
Please add any other relevant info below:
-->
