### PR TITLE
aarch64 linux: fix docker image used in linux_aarch64_USE_OPENMPx build configs

### DIFF
--- a/.ci_support/linux_aarch64_USE_OPENMP0.yaml
+++ b/.ci_support/linux_aarch64_USE_OPENMP0.yaml
@@ -19,7 +19,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- quay.io/condaforge/linux-anvil-aarch64
 fortran_compiler:
 - gfortran
 fortran_compiler_version:

--- a/.ci_support/linux_aarch64_USE_OPENMP1.yaml
+++ b/.ci_support/linux_aarch64_USE_OPENMP1.yaml
@@ -19,7 +19,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- quay.io/condaforge/linux-anvil-aarch64
 fortran_compiler:
 - gfortran
 fortran_compiler_version:


### PR DESCRIPTION
updated the aarch64 linux build config yaml files to pull aarch64 condaforge docker image instead of x86 version. with this change, the local builds are working fine on aarch64 platform.
fixes this issue: https://github.com/conda-forge/openblas-feedstock/issues/157

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
This PR fixes the issue# https://github.com/conda-forge/openblas-feedstock/issues/157
<!--
Please add any other relevant info below:
-->
