### PR TITLE
remove track_features for openmp

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -78,6 +78,8 @@ outputs:
     build:
       string: openmp_h{{ PKG_HASH }}_{{ build_number }}  # [USE_OPENMP == 1]
       string: pthreads_h{{ PKG_HASH }}_{{ build_number }}  # [USE_OPENMP == 0]
+      run_exports:
+        - {{ pin_subpackage("libopenblas" ~ name_suffix) }}
     files:
       - include/*.h                                       # [not win]
       - lib/libopenblas{{ SYMBOLSUFFIX }}*.a              # [not win]


### PR DESCRIPTION
Any package that might call blas from openmp must conflict with the pthreads build of openmp. From the openblas [faq](https://github.com/OpenMathLib/OpenBLAS/wiki/Faq#OpenMP):

> OpenMP provides its own locking mechanisms, so when your code makes BLAS/LAPACK calls from inside OpenMP parallel regions it is imperative that you use an OpenBLAS that is built with USE_OPENMP=1, as otherwise deadlocks might occur.

But adding the required constraint:

```yaml
run_constrained:
  - openblas=*=*openmp*
```

to exclude the incompatible pthreads build results in a default solve with `libblas=*=blis` and `liblapack=*=netlib` due to the features minimization to exclude openmp having higher priority than the preference for openblas.

 In general, the opemp builds of openblas should be strictly more compatible, so I'm not sure why it's deprioritized so severely (in #99). The [test case there](https://github.com/conda-forge/openblas-feedstock/pull/99#issuecomment-658574446) doesn't give any errors with `libopenblas=0.3.27=openmp_h25fa9fd_1` and `llvm-openmp=18.1.8=hf5423f3_1`.

Maybe there's another way to weigh down netlib _even more_ so `liblapack=*=openblas + openblas=*=*openmp*` is a preferred solution to `liblapack=*=netlib`? Would adding more features on liblapack netlib do that?


I also added the missing `run_exports` to `openblas`, which is the package required in host dependencies for linking openblas.