### PR TITLE
build.sh: set TARGET/BINARY/DYNAMIC_ARCH for linux-riscv64

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -51,7 +51,7 @@ jobs:
       osx_arm64_INTERFACE640SYMBOLSUFFIXUSE_OPENMP0name_suffix:
         CONFIG: osx_arm64_INTERFACE640SYMBOLSUFFIXUSE_OPENMP0name_suffix
         UPLOAD_PACKAGES: 'True'
-        VMIMAGE: macOS-15
+        VMIMAGE: macOS-15-arm64
         build_workspace_dir: ~/miniforge3/conda-bld
         free_disk_space: skip
         pagefile_size: 0
@@ -61,7 +61,7 @@ jobs:
       osx_arm64_INTERFACE640SYMBOLSUFFIXUSE_OPENMP1name_suffix:
         CONFIG: osx_arm64_INTERFACE640SYMBOLSUFFIXUSE_OPENMP1name_suffix
         UPLOAD_PACKAGES: 'True'
-        VMIMAGE: macOS-15
+        VMIMAGE: macOS-15-arm64
         build_workspace_dir: ~/miniforge3/conda-bld
         free_disk_space: skip
         pagefile_size: 0
@@ -71,7 +71,7 @@ jobs:
       osx_arm64_INTERFACE641SYMBOLSUFFIX64_USE_OPENMP0name_suffix-ilp64:
         CONFIG: osx_arm64_INTERFACE641SYMBOLSUFFIX64_USE_OPENMP0name_suffix-ilp64
         UPLOAD_PACKAGES: 'True'
-        VMIMAGE: macOS-15
+        VMIMAGE: macOS-15-arm64
         build_workspace_dir: ~/miniforge3/conda-bld
         free_disk_space: skip
         pagefile_size: 0
@@ -81,7 +81,7 @@ jobs:
       osx_arm64_INTERFACE641SYMBOLSUFFIX64_USE_OPENMP1name_suffix-ilp64:
         CONFIG: osx_arm64_INTERFACE641SYMBOLSUFFIX64_USE_OPENMP1name_suffix-ilp64
         UPLOAD_PACKAGES: 'True'
-        VMIMAGE: macOS-15
+        VMIMAGE: macOS-15-arm64
         build_workspace_dir: ~/miniforge3/conda-bld
         free_disk_space: skip
         pagefile_size: 0

--- a/.ci_support/linux_64_INTERFACE640SYMBOLSUFFIXUSE_OPENMP0name_suffix.yaml
+++ b/.ci_support/linux_64_INTERFACE640SYMBOLSUFFIXUSE_OPENMP0name_suffix.yaml
@@ -7,7 +7,7 @@ USE_OPENMP:
 c_compiler:
 - gcc
 c_compiler_version:
-- '14'
+- '15'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -21,7 +21,7 @@ docker_image:
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '14'
+- '15'
 name_suffix:
 - ''
 openblas:

--- a/.ci_support/linux_64_INTERFACE640SYMBOLSUFFIXUSE_OPENMP1name_suffix.yaml
+++ b/.ci_support/linux_64_INTERFACE640SYMBOLSUFFIXUSE_OPENMP1name_suffix.yaml
@@ -7,7 +7,7 @@ USE_OPENMP:
 c_compiler:
 - gcc
 c_compiler_version:
-- '14'
+- '15'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -21,7 +21,7 @@ docker_image:
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '14'
+- '15'
 name_suffix:
 - ''
 openblas:

--- a/.ci_support/linux_64_INTERFACE641SYMBOLSUFFIX64_USE_OPENMP0name_suffix-ilp64.yaml
+++ b/.ci_support/linux_64_INTERFACE641SYMBOLSUFFIX64_USE_OPENMP0name_suffix-ilp64.yaml
@@ -7,7 +7,7 @@ USE_OPENMP:
 c_compiler:
 - gcc
 c_compiler_version:
-- '14'
+- '15'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -21,7 +21,7 @@ docker_image:
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '14'
+- '15'
 name_suffix:
 - -ilp64
 openblas:

--- a/.ci_support/linux_64_INTERFACE641SYMBOLSUFFIX64_USE_OPENMP1name_suffix-ilp64.yaml
+++ b/.ci_support/linux_64_INTERFACE641SYMBOLSUFFIX64_USE_OPENMP1name_suffix-ilp64.yaml
@@ -7,7 +7,7 @@ USE_OPENMP:
 c_compiler:
 - gcc
 c_compiler_version:
-- '14'
+- '15'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -21,7 +21,7 @@ docker_image:
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '14'
+- '15'
 name_suffix:
 - -ilp64
 openblas:

--- a/.ci_support/linux_aarch64_INTERFACE640SYMBOLSUFFIXUSE_OPENMP0name_suffix.yaml
+++ b/.ci_support/linux_aarch64_INTERFACE640SYMBOLSUFFIXUSE_OPENMP0name_suffix.yaml
@@ -7,7 +7,7 @@ USE_OPENMP:
 c_compiler:
 - gcc
 c_compiler_version:
-- '14'
+- '15'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -17,11 +17,11 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma10
+- quay.io/condaforge/linux-anvil-aarch64:alma10
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '14'
+- '15'
 name_suffix:
 - ''
 openblas:

--- a/.ci_support/linux_aarch64_INTERFACE640SYMBOLSUFFIXUSE_OPENMP1name_suffix.yaml
+++ b/.ci_support/linux_aarch64_INTERFACE640SYMBOLSUFFIXUSE_OPENMP1name_suffix.yaml
@@ -7,7 +7,7 @@ USE_OPENMP:
 c_compiler:
 - gcc
 c_compiler_version:
-- '14'
+- '15'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -17,11 +17,11 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma10
+- quay.io/condaforge/linux-anvil-aarch64:alma10
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '14'
+- '15'
 name_suffix:
 - ''
 openblas:

--- a/.ci_support/linux_aarch64_INTERFACE641SYMBOLSUFFIX64_USE_OPENMP0name_suffix-ilp64.yaml
+++ b/.ci_support/linux_aarch64_INTERFACE641SYMBOLSUFFIX64_USE_OPENMP0name_suffix-ilp64.yaml
@@ -7,7 +7,7 @@ USE_OPENMP:
 c_compiler:
 - gcc
 c_compiler_version:
-- '14'
+- '15'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -17,11 +17,11 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma10
+- quay.io/condaforge/linux-anvil-aarch64:alma10
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '14'
+- '15'
 name_suffix:
 - -ilp64
 openblas:

--- a/.ci_support/linux_aarch64_INTERFACE641SYMBOLSUFFIX64_USE_OPENMP1name_suffix-ilp64.yaml
+++ b/.ci_support/linux_aarch64_INTERFACE641SYMBOLSUFFIX64_USE_OPENMP1name_suffix-ilp64.yaml
@@ -7,7 +7,7 @@ USE_OPENMP:
 c_compiler:
 - gcc
 c_compiler_version:
-- '14'
+- '15'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -17,11 +17,11 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma10
+- quay.io/condaforge/linux-anvil-aarch64:alma10
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '14'
+- '15'
 name_suffix:
 - -ilp64
 openblas:

--- a/.ci_support/linux_ppc64le_INTERFACE640SYMBOLSUFFIXUSE_OPENMP0name_suffix.yaml
+++ b/.ci_support/linux_ppc64le_INTERFACE640SYMBOLSUFFIXUSE_OPENMP0name_suffix.yaml
@@ -7,7 +7,7 @@ USE_OPENMP:
 c_compiler:
 - gcc
 c_compiler_version:
-- '14'
+- '15'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -21,7 +21,7 @@ docker_image:
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '14'
+- '15'
 name_suffix:
 - ''
 openblas:

--- a/.ci_support/linux_ppc64le_INTERFACE640SYMBOLSUFFIXUSE_OPENMP1name_suffix.yaml
+++ b/.ci_support/linux_ppc64le_INTERFACE640SYMBOLSUFFIXUSE_OPENMP1name_suffix.yaml
@@ -7,7 +7,7 @@ USE_OPENMP:
 c_compiler:
 - gcc
 c_compiler_version:
-- '14'
+- '15'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -21,7 +21,7 @@ docker_image:
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '14'
+- '15'
 name_suffix:
 - ''
 openblas:

--- a/.ci_support/linux_ppc64le_INTERFACE641SYMBOLSUFFIX64_USE_OPENMP0name_suffix-ilp64.yaml
+++ b/.ci_support/linux_ppc64le_INTERFACE641SYMBOLSUFFIX64_USE_OPENMP0name_suffix-ilp64.yaml
@@ -7,7 +7,7 @@ USE_OPENMP:
 c_compiler:
 - gcc
 c_compiler_version:
-- '14'
+- '15'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -21,7 +21,7 @@ docker_image:
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '14'
+- '15'
 name_suffix:
 - -ilp64
 openblas:

--- a/.ci_support/linux_ppc64le_INTERFACE641SYMBOLSUFFIX64_USE_OPENMP1name_suffix-ilp64.yaml
+++ b/.ci_support/linux_ppc64le_INTERFACE641SYMBOLSUFFIX64_USE_OPENMP1name_suffix-ilp64.yaml
@@ -7,7 +7,7 @@ USE_OPENMP:
 c_compiler:
 - gcc
 c_compiler_version:
-- '14'
+- '15'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -21,7 +21,7 @@ docker_image:
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '14'
+- '15'
 name_suffix:
 - -ilp64
 openblas:

--- a/.ci_support/linux_riscv64_INTERFACE640SYMBOLSUFFIXUSE_OPENMP0name_suffix.yaml
+++ b/.ci_support/linux_riscv64_INTERFACE640SYMBOLSUFFIXUSE_OPENMP0name_suffix.yaml
@@ -7,7 +7,7 @@ USE_OPENMP:
 c_compiler:
 - gcc
 c_compiler_version:
-- '14'
+- '15'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -21,7 +21,7 @@ docker_image:
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '14'
+- '15'
 name_suffix:
 - ''
 openblas:

--- a/.ci_support/linux_riscv64_INTERFACE640SYMBOLSUFFIXUSE_OPENMP0name_suffix.yaml
+++ b/.ci_support/linux_riscv64_INTERFACE640SYMBOLSUFFIXUSE_OPENMP0name_suffix.yaml
@@ -1,0 +1,38 @@
+INTERFACE64:
+- '0'
+SYMBOLSUFFIX:
+- ''
+USE_OPENMP:
+- '0'
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.39'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma10
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '14'
+name_suffix:
+- ''
+openblas:
+- 0.3.*
+perl:
+- 5.32.1
+target_platform:
+- linux-riscv64
+zip_keys:
+- - SYMBOLSUFFIX
+  - name_suffix
+  - INTERFACE64
+- - c_compiler_version
+  - fortran_compiler_version

--- a/.ci_support/linux_riscv64_INTERFACE640SYMBOLSUFFIXUSE_OPENMP1name_suffix.yaml
+++ b/.ci_support/linux_riscv64_INTERFACE640SYMBOLSUFFIXUSE_OPENMP1name_suffix.yaml
@@ -1,0 +1,38 @@
+INTERFACE64:
+- '0'
+SYMBOLSUFFIX:
+- ''
+USE_OPENMP:
+- '1'
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.39'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma10
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '14'
+name_suffix:
+- ''
+openblas:
+- 0.3.*
+perl:
+- 5.32.1
+target_platform:
+- linux-riscv64
+zip_keys:
+- - SYMBOLSUFFIX
+  - name_suffix
+  - INTERFACE64
+- - c_compiler_version
+  - fortran_compiler_version

--- a/.ci_support/linux_riscv64_INTERFACE640SYMBOLSUFFIXUSE_OPENMP1name_suffix.yaml
+++ b/.ci_support/linux_riscv64_INTERFACE640SYMBOLSUFFIXUSE_OPENMP1name_suffix.yaml
@@ -7,7 +7,7 @@ USE_OPENMP:
 c_compiler:
 - gcc
 c_compiler_version:
-- '14'
+- '15'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -21,7 +21,7 @@ docker_image:
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '14'
+- '15'
 name_suffix:
 - ''
 openblas:

--- a/.ci_support/linux_riscv64_INTERFACE641SYMBOLSUFFIX64_USE_OPENMP0name_suffix-ilp64.yaml
+++ b/.ci_support/linux_riscv64_INTERFACE641SYMBOLSUFFIX64_USE_OPENMP0name_suffix-ilp64.yaml
@@ -7,7 +7,7 @@ USE_OPENMP:
 c_compiler:
 - gcc
 c_compiler_version:
-- '14'
+- '15'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -21,7 +21,7 @@ docker_image:
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '14'
+- '15'
 name_suffix:
 - -ilp64
 openblas:

--- a/.ci_support/linux_riscv64_INTERFACE641SYMBOLSUFFIX64_USE_OPENMP0name_suffix-ilp64.yaml
+++ b/.ci_support/linux_riscv64_INTERFACE641SYMBOLSUFFIX64_USE_OPENMP0name_suffix-ilp64.yaml
@@ -1,0 +1,38 @@
+INTERFACE64:
+- '1'
+SYMBOLSUFFIX:
+- '64_'
+USE_OPENMP:
+- '0'
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.39'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma10
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '14'
+name_suffix:
+- -ilp64
+openblas:
+- 0.3.*
+perl:
+- 5.32.1
+target_platform:
+- linux-riscv64
+zip_keys:
+- - SYMBOLSUFFIX
+  - name_suffix
+  - INTERFACE64
+- - c_compiler_version
+  - fortran_compiler_version

--- a/.ci_support/linux_riscv64_INTERFACE641SYMBOLSUFFIX64_USE_OPENMP1name_suffix-ilp64.yaml
+++ b/.ci_support/linux_riscv64_INTERFACE641SYMBOLSUFFIX64_USE_OPENMP1name_suffix-ilp64.yaml
@@ -7,7 +7,7 @@ USE_OPENMP:
 c_compiler:
 - gcc
 c_compiler_version:
-- '14'
+- '15'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -21,7 +21,7 @@ docker_image:
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '14'
+- '15'
 name_suffix:
 - -ilp64
 openblas:

--- a/.ci_support/linux_riscv64_INTERFACE641SYMBOLSUFFIX64_USE_OPENMP1name_suffix-ilp64.yaml
+++ b/.ci_support/linux_riscv64_INTERFACE641SYMBOLSUFFIX64_USE_OPENMP1name_suffix-ilp64.yaml
@@ -1,0 +1,38 @@
+INTERFACE64:
+- '1'
+SYMBOLSUFFIX:
+- '64_'
+USE_OPENMP:
+- '1'
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.39'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma10
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '14'
+name_suffix:
+- -ilp64
+openblas:
+- 0.3.*
+perl:
+- 5.32.1
+target_platform:
+- linux-riscv64
+zip_keys:
+- - SYMBOLSUFFIX
+  - name_suffix
+  - INTERFACE64
+- - c_compiler_version
+  - fortran_compiler_version

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -166,6 +166,54 @@ jobs:
             resize_partitions: False
             runs_on: ['ubuntu-latest']
             tools_install_dir: ~/miniforge3
+          - CONFIG: linux_riscv64_INTERFACE640SYMBOLSUFFIXUSE_OPENMP0name_suffix
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma10
+            STORE_BUILD_ARTIFACTS: False
+            UPLOAD_PACKAGES: True
+            build_workspace_dir: build_artifacts
+            docker_run_args: 
+            free_disk_space: skip
+            os: ubuntu
+            pagefile_size: 0
+            resize_partitions: False
+            runs_on: ['ubuntu-latest']
+            tools_install_dir: ~/miniforge3
+          - CONFIG: linux_riscv64_INTERFACE640SYMBOLSUFFIXUSE_OPENMP1name_suffix
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma10
+            STORE_BUILD_ARTIFACTS: False
+            UPLOAD_PACKAGES: True
+            build_workspace_dir: build_artifacts
+            docker_run_args: 
+            free_disk_space: skip
+            os: ubuntu
+            pagefile_size: 0
+            resize_partitions: False
+            runs_on: ['ubuntu-latest']
+            tools_install_dir: ~/miniforge3
+          - CONFIG: linux_riscv64_INTERFACE641SYMBOLSUFFIX64_USE_OPENMP0name_suffix-ilp64
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma10
+            STORE_BUILD_ARTIFACTS: False
+            UPLOAD_PACKAGES: True
+            build_workspace_dir: build_artifacts
+            docker_run_args: 
+            free_disk_space: skip
+            os: ubuntu
+            pagefile_size: 0
+            resize_partitions: False
+            runs_on: ['ubuntu-latest']
+            tools_install_dir: ~/miniforge3
+          - CONFIG: linux_riscv64_INTERFACE641SYMBOLSUFFIX64_USE_OPENMP1name_suffix-ilp64
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma10
+            STORE_BUILD_ARTIFACTS: False
+            UPLOAD_PACKAGES: True
+            build_workspace_dir: build_artifacts
+            docker_run_args: 
+            free_disk_space: skip
+            os: ubuntu
+            pagefile_size: 0
+            resize_partitions: False
+            runs_on: ['ubuntu-latest']
+            tools_install_dir: ~/miniforge3
     steps:
 
     - name: Checkout code

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -71,7 +71,7 @@ jobs:
             runs_on: ['ubuntu-latest']
             tools_install_dir: ~/miniforge3
           - CONFIG: linux_aarch64_INTERFACE640SYMBOLSUFFIXUSE_OPENMP0name_suffix
-            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma10
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64:alma10
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             build_workspace_dir: build_artifacts
@@ -80,10 +80,10 @@ jobs:
             os: ubuntu
             pagefile_size: 0
             resize_partitions: False
-            runs_on: ['ubuntu-latest']
+            runs_on: ['ubuntu-24.04-arm']
             tools_install_dir: ~/miniforge3
           - CONFIG: linux_aarch64_INTERFACE640SYMBOLSUFFIXUSE_OPENMP1name_suffix
-            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma10
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64:alma10
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             build_workspace_dir: build_artifacts
@@ -92,10 +92,10 @@ jobs:
             os: ubuntu
             pagefile_size: 0
             resize_partitions: False
-            runs_on: ['ubuntu-latest']
+            runs_on: ['ubuntu-24.04-arm']
             tools_install_dir: ~/miniforge3
           - CONFIG: linux_aarch64_INTERFACE641SYMBOLSUFFIX64_USE_OPENMP0name_suffix-ilp64
-            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma10
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64:alma10
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             build_workspace_dir: build_artifacts
@@ -104,10 +104,10 @@ jobs:
             os: ubuntu
             pagefile_size: 0
             resize_partitions: False
-            runs_on: ['ubuntu-latest']
+            runs_on: ['ubuntu-24.04-arm']
             tools_install_dir: ~/miniforge3
           - CONFIG: linux_aarch64_INTERFACE641SYMBOLSUFFIX64_USE_OPENMP1name_suffix-ilp64
-            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma10
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64:alma10
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             build_workspace_dir: build_artifacts
@@ -116,7 +116,7 @@ jobs:
             os: ubuntu
             pagefile_size: 0
             resize_partitions: False
-            runs_on: ['ubuntu-latest']
+            runs_on: ['ubuntu-24.04-arm']
             tools_install_dir: ~/miniforge3
           - CONFIG: linux_ppc64le_INTERFACE640SYMBOLSUFFIXUSE_OPENMP0name_suffix
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma10

--- a/README.md
+++ b/README.md
@@ -90,6 +90,34 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>osx_arm64_INTERFACE640SYMBOLSUFFIXUSE_OPENMP0name_suffix</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=716&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/openblas-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_INTERFACE640SYMBOLSUFFIXUSE_OPENMP0name_suffix" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_INTERFACE640SYMBOLSUFFIXUSE_OPENMP1name_suffix</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=716&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/openblas-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_INTERFACE640SYMBOLSUFFIXUSE_OPENMP1name_suffix" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_INTERFACE641SYMBOLSUFFIX64_USE_OPENMP0name_suffix-ilp64</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=716&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/openblas-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_INTERFACE641SYMBOLSUFFIX64_USE_OPENMP0name_suffix-ilp64" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_INTERFACE641SYMBOLSUFFIX64_USE_OPENMP1name_suffix-ilp64</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=716&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/openblas-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_INTERFACE641SYMBOLSUFFIX64_USE_OPENMP1name_suffix-ilp64" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>win_64_USE_OPENMP0</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=716&branchName=main">

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,8 +1,6 @@
 build_platform:
-  linux_aarch64: linux_64
   linux_ppc64le: linux_64
   linux_riscv64: linux_64
-  osx_arm64: osx_64
 conda_build:
   pkg_format: '2'
 conda_forge_output_validation: true
@@ -13,4 +11,7 @@ idle_timeout_minutes: 30
 remote_ci_setup:
 - conda-forge-ci-setup=4
 - conda-build <24.11
+provider:
+  linux_aarch64: default
+  osx_arm64: default
 test: native_and_emulated

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,6 +1,7 @@
 build_platform:
   linux_aarch64: linux_64
   linux_ppc64le: linux_64
+  linux_riscv64: linux_64
   osx_arm64: osx_64
 conda_build:
   pkg_format: '2'
@@ -10,7 +11,6 @@ github:
   tooling_branch_name: main
 idle_timeout_minutes: 30
 remote_ci_setup:
-  - conda-forge-ci-setup=4
-  # https://github.com/conda/conda-build/issues/5613
-  - conda-build <24.11
+- conda-forge-ci-setup=4
+- conda-build <24.11
 test: native_and_emulated

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -53,6 +53,9 @@ elif [[ "${target_platform}" == osx-arm64 ]]; then
   TARGET="VORTEX"
   BINARY="64"
   DYNAMIC_ARCH=0
+else
+  echo "Unknown platform ${target_platform}"
+  exit 1
 fi
 
 QUIET_MAKE=0

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -38,6 +38,12 @@ elif [[ "${target_platform}" == linux-64 ]]; then
   BUILD_BFLOAT16=1
   BINARY="64"
   DYNAMIC_ARCH=1
+elif [[ "${target_platform}" == linux-riscv64 ]]; then
+  # RISCV64_GENERIC is the baseline; DYNAMIC_ARCH adds the RVV 1.0 kernels
+  # (RISCV64_ZVL128B/ZVL256B), dispatched at runtime via the hwprobe syscall.
+  TARGET="RISCV64_GENERIC"
+  BINARY="64"
+  DYNAMIC_ARCH=1
 elif [[ "${target_platform}" == osx-64 ]]; then
   TARGET="CORE2"
   BUILD_BFLOAT16=1

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,9 +1,7 @@
-# gcc 12 cannot handle `-mtune=native` on aarch,
-# gcc 13 causes test failures on ppc
 c_compiler_version:         # [linux]
-  - 14                      # [linux]
+  - 15                      # [linux]
 fortran_compiler_version:   # [linux]
-  - 14                      # [linux]
+  - 15                      # [linux]
 
 SYMBOLSUFFIX:
   - ""

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "0.3.34" %}
-{% set build_number = 0 %}
+{% set build_number = 1 %}
 
 # ensure INTERFACE64 variable gets detected by conda-build
 # [INTERFACE64 == "foobar"]


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Part of #192 (linux-riscv64 migration).

recipe/build.sh has no linux-riscv64 branch, so TARGET, BINARY and DYNAMIC_ARCH are all empty. With TARGET empty, OpenBLAS falls back to getarch, which runs on the x86_64 build host and picks a Zen core (hence libopenblas_zenp-r0.3.34.a), leaving no valid kernel config for ARCH=riscv64:

`make[1]: *** No rule to make target '../kernel/riscv64/amax.S', needed by 'samax_k.o'.  Stop.
`
<!--
Please add any other relevant info below:
-->
